### PR TITLE
Fix switch statement control flow analysis

### DIFF
--- a/src/main/java/cfg/CFGFactory.java
+++ b/src/main/java/cfg/CFGFactory.java
@@ -1,5 +1,6 @@
 package cfg;
 
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -324,9 +325,16 @@ public class CFGFactory
 
 			boolean defaultLabel = false;
 
+			HashMap<String, CFGNode> nonCaseLabels = new HashMap<>();
 			for (Entry<String, CFGNode> block : switchBody.getLabels()
 					.entrySet())
 			{
+				// Skip labels that aren't for switch statements.
+				if (!block.getKey().matches("^(case|default).*")) {
+					nonCaseLabels.put(block.getKey(), block.getValue());
+					continue;
+				}
+
 				if (block.getKey().equals("default"))
 				{
 					defaultLabel = true;
@@ -334,6 +342,13 @@ public class CFGFactory
 				switchBlock.addEdge(conditionContainer, block.getValue(),
 						block.getKey());
 			}
+
+			// Hide case/default labels from upstream CFG analysis, they can't
+			// reference internal labels anyway and this prevents bugs with
+			// nested switch statements where the parent switch statement
+			// references the childs labels.
+			switchBlock.setLabels(nonCaseLabels);
+
 			for (CFGEdge edge : switchBody
 					.incomingEdges(switchBody.getExitNode()))
 			{

--- a/src/main/java/cfg/CFGFactory.java
+++ b/src/main/java/cfg/CFGFactory.java
@@ -330,7 +330,8 @@ public class CFGFactory
 					.entrySet())
 			{
 				// Skip labels that aren't for switch statements.
-				if (!block.getKey().matches("^(case|default).*")) {
+				if (!block.getKey().matches("^(case|default).*"))
+				{
 					nonCaseLabels.put(block.getKey(), block.getValue());
 					continue;
 				}


### PR DESCRIPTION
The switch statement control flow analysis has two bugs. Currently it
adds CF edges to every label in the switch body, including: 1)
labels not related to the control flow [e.g. goto labels, not
case/default labels], and 2) for nested switch statements the parent
switch statement includes direct edges to the child switch statements
labels. This change skips goto labels, and doesn't propagate
case/default labels up to avoid the nested switch statement problem
(other contexts can't reference to the switch statement case/default
labels anyway so that should be fine.)
